### PR TITLE
chore(deps): update cargo_toml dependency to version 0.22.1 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ path = "src/main.rs"
 # and it will keep the alphabetic ordering for you.
 [dependencies]
 cargo-options = "0.1.3"
-cargo_toml = "0.11.5"
+cargo_toml = "0.22.1"
 clap = { version = "3.1.6", features = ["derive"] }
 colored = "2"
 home = "0.5.3"


### PR DESCRIPTION
cargo_toml = "0.11.x" is yanked.